### PR TITLE
Synced state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# orbslam2-ros2
+
+Comprehensive ROS 2 package for the [ORB_SLAM2](https://github.com/raulmur/ORB_SLAM2) real-time SLAM library.
+Currently supports Intel RealSense cameras, and offers many configuration options.
+Written in C++.
+
+**Work in progress as of August 15, 2021.**

--- a/include/orbslam2-ros2/orbslam2_ros2.hpp
+++ b/include/orbslam2-ros2/orbslam2_ros2.hpp
@@ -82,13 +82,10 @@ public:
 
 private:
     void timer_vio_callback(void);
-    void timer_state_callback(void);
 
-    rclcpp::CallbackGroup::SharedPtr state_clbk_group_;
     rclcpp::CallbackGroup::SharedPtr vio_clbk_group_;
 
     rclcpp::TimerBase::SharedPtr vio_timer_;
-    rclcpp::TimerBase::SharedPtr state_timer_;
 
     rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr state_publisher_;
 


### PR DESCRIPTION
Tracking state (as of Tracking::eTrackingState enum) is published with sensor_data QoS as soon as a new pose sample is. The idea is to make this information coherent with pose data (including when this is extrapolated/oversampled). The node remains generic and not tied to any specific project.